### PR TITLE
feat: Detect user Android Studio installation path on OSX

### DIFF
--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -426,7 +426,12 @@ async function determineAndroidStudioPath(os: OS): Promise<string> {
 
   switch (os) {
     case OS.Mac:
-      return '/Applications/Android Studio.app';
+      const systemWideInstallationPath = '/Applications/Android Studio.app';
+      const userInstallationPath = '$HOME/Applications/Android Studio.app';
+
+      return await pathExists(userInstallationPath)
+        ? userInstallationPath
+        : systemWideInstallationPath;
     case OS.Windows: {
       const { runCommand } = await import('./util/subprocess');
 


### PR DESCRIPTION
It is fairly common for Android Studio to be installed for the user only, rather than for all the machine users. This PR allows to detect such installation and prioritize the user installation over the global user installation.